### PR TITLE
Bug fixes, extend the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ test_run = project123.run
 p "Project state #{test_run.state}"
 
 #download all logs from test run
-test_run.device_runs.list.each { |drun| drun.download_logs("#{drun.id}_log") }
+test_run.device_runs.list({:params => {:limit => 100}}).each { |drun| drun.download_logs("#{drun.id}_log") }
 
 #Get label for android os version 2.1
 lg_android_version_2_1 = client.label_groups.list.detect {|lg| lg.display_name.casecmp("android version") == 0 }

--- a/lib/testdroid_api/client.rb
+++ b/lib/testdroid_api/client.rb
@@ -70,14 +70,14 @@ module TestdroidAPI
 			end
 			 JSON.parse(resp.body)
 		end		  
-		def get(uri) 
+		def get(uri, params={}) 
 				
 				@logger.error "token expired" if @token.expired?
 				
 				@token = @client.password.get_token(@username, @password) if  @token.expired?
 				
 				begin 
-					resp = @token.get(@cloud_url+"#{uri}",  :headers => ACCEPT_HEADERS)
+					resp = @token.get(@cloud_url+"#{uri}", params.merge(:headers => ACCEPT_HEADERS))
 				rescue => e
 					@logger.error "Failed to get resource #{uri} #{e}"
 					return nil

--- a/lib/testdroid_api/cloud_list_resource.rb
+++ b/lib/testdroid_api/cloud_list_resource.rb
@@ -19,7 +19,7 @@ module TestdroidAPI
 				raise "Can't get a resource list without a REST Client" unless @client
 				@uri = full_uri ? @uri.split(@client.instance_variable_get(:@cloud_url))[1] : @uri
 
-				response = @client.get( @uri)
+				response = @client.get(@uri, params)
 				
 				if response['data'].is_a?(Array) 
 					client = @client


### PR DESCRIPTION
1) Actually allow an alternative logger to be passed in, and then actually use it (don't dump all output to stdout)
2) Allow passing in parameters with GET requests, e.g. to allow listing more than 20 objects (the default limit)

NOTE: rspecs appear to be broken when I run them locally so I was not able to verify against them.
